### PR TITLE
Add support for GitHub compare URLs that don't conform to URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Makes the CircleCI provider validate, but not run on non-PR builds - orta
 * Take the git before...after references out of ENV vars from CI providers - orta
+* Fixes CircleCI when dealing with URLs like `https://github.com/artsy/eigen/compare/b0f6a2a9ff6f%5E...316b694875c8` - orta
 
 ## 0.2.1
 

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -17,13 +17,22 @@ module Danger
           self.pull_request_id = paths[4]
         end
 
-        if env["CIRCLE_COMPARE_URL"] && URI.parse(env["CIRCLE_COMPARE_URL"]).path.split("/").count == 5
-          commit_ref = URI.parse(env["CIRCLE_COMPARE_URL"]).path.split("/").last
+        # The url we get from Circle can include "^" which isn't allowed in
+        # ruby's URI, so we decode to a URL then unencode at the end.
+
+        if env["CIRCLE_COMPARE_URL"]
+          compare_encoded = URI.escape(env["CIRCLE_COMPARE_URL"])
+          url =  URI.parse(compare_encoded)
+
+          return unless url.path.split("/").count == 5
+
+          commit_ref = URI.unescape(url.path.split("/").last)
 
           self.head_commit = commit_ref.split("...").last
           self.base_commit = commit_ref.split("...").first
         end
       end
+
     end
   end
 end

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -32,7 +32,6 @@ module Danger
           self.base_commit = commit_ref.split("...").first
         end
       end
-
     end
   end
 end

--- a/spec/sources/circle_spec.rb
+++ b/spec/sources/circle_spec.rb
@@ -38,4 +38,16 @@ describe Danger::CISource::CircleCI do
     expect(t.base_commit).to eql("759adcbd0d8f")
     expect(t.head_commit).to eql("13c4dc8bb61d")
   end
+
+  it 'handles funky compare URLs' do
+    env = {
+      "CIRCLE_BUILD_NUM" => "true",
+      "CI_PULL_REQUEST" => "https://github.com/artsy/eigen/pull/800",
+      "CIRCLE_COMPARE_URL" => "https://github.com/artsy/eigen/compare/759adcbd0d8f^...13c4dc8bb61d"
+    }
+    t = Danger::CISource::CircleCI.new(env)
+    expect(t.base_commit).to eql("759adcbd0d8f^")
+    expect(t.head_commit).to eql("13c4dc8bb61d")
+  end
+
 end

--- a/spec/sources/circle_spec.rb
+++ b/spec/sources/circle_spec.rb
@@ -49,5 +49,4 @@ describe Danger::CISource::CircleCI do
     expect(t.base_commit).to eql("759adcbd0d8f^")
     expect(t.head_commit).to eql("13c4dc8bb61d")
   end
-
 end


### PR DESCRIPTION
This PR https://github.com/artsy/eigen/pull/1076 totally threw me for a loop, I have no idea why we're being passed such a funky URL, but now we [don't crash](https://circleci.com/gh/artsy/eigen/1389). 