### PR TITLE
Make sure we grab all comments for github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Makes the CircleCI provider validate, but not run on non-PR builds - orta
 * Take the git before...after references out of ENV vars from CI providers - orta
 * Fixes CircleCI when dealing with URLs like `https://github.com/artsy/eigen/compare/b0f6a2a9ff6f%5E...316b694875c8` - orta
+* Ensure all comments are downloaded, previously it was capped at 30 - orta
 
 ## 0.2.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,20 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'rubocop/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:specs)
 
 task default: :spec
+
+task :spec do
+  Rake::Task['specs'].invoke
+  Rake::Task['rubocop'].invoke
+end
+
+desc 'Run RuboCop on the lib/specs directory'
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.patterns = ['lib/**/*.rb', 'spec/**/*.rb']
+end
 
 task :test do
   sh "fastlane test"

--- a/lib/danger/ci_source/circle.rb
+++ b/lib/danger/ci_source/circle.rb
@@ -5,8 +5,7 @@ module Danger
   module CISource
     class CircleCI < CI
       def self.validates?(env)
-        return !env["CIRCLE_BUILD_NUM"].nil? &&
-               !env["CI_PULL_REQUEST"].nil?
+        return !env["CIRCLE_BUILD_NUM"].nil? && !env["CI_PULL_REQUEST"].nil?
       end
 
       def initialize(env)

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -11,6 +11,8 @@ module Danger
     def initialize(ci_source, environment)
       self.ci_source = ci_source
       self.environment = environment
+
+      Octokit.auto_paginate = true
     end
 
     def client
@@ -50,7 +52,7 @@ module Danger
         # Just remove the comment, if there's nothing to say.
         delete_old_comments!
       else
-        issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id, auto_pagination: true)
+        issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
         editable_issues = issues.reject { |issue| issue[:body].include?("generated_by_danger") == false }
         body = generate_comment(warnings: warnings, errors: errors, messages: messages)
 
@@ -91,7 +93,7 @@ module Danger
 
     # Get rid of the previously posted comment, to only have the latest one
     def delete_old_comments!(except: nil)
-      issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id, auto_pagination: true)
+      issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
       issues.each do |issue|
         next unless issue[:body].include?("generated_by_danger")
         next if issue[:id] == except

--- a/lib/danger/request_sources/github.rb
+++ b/lib/danger/request_sources/github.rb
@@ -50,7 +50,7 @@ module Danger
         # Just remove the comment, if there's nothing to say.
         delete_old_comments!
       else
-        issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
+        issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id, auto_pagination: true)
         editable_issues = issues.reject { |issue| issue[:body].include?("generated_by_danger") == false }
         body = generate_comment(warnings: warnings, errors: errors, messages: messages)
 
@@ -91,7 +91,7 @@ module Danger
 
     # Get rid of the previously posted comment, to only have the latest one
     def delete_old_comments!(except: nil)
-      issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id)
+      issues = client.issue_comments(ci_source.repo_slug, ci_source.pull_request_id, auto_pagination: true)
       issues.each do |issue|
         next unless issue[:body].include?("generated_by_danger")
         next if issue[:id] == except

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -93,7 +93,7 @@ describe Danger::GitHub do
     describe "issue creation" do
       it "creates an issue if no danger comments exist" do
         issues = []
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800", { :auto_pagination => true }).and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
 
         body = @g.generate_comment(warnings: ["hi"], errors: [], messages: [])
         expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
@@ -103,7 +103,7 @@ describe Danger::GitHub do
 
       it "updates the issue if no danger comments exist" do
         issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800", { :auto_pagination => true }).and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
 
         body = @g.generate_comment(warnings: ["hi"], errors: [], messages: [])
         expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", body).and_return({})
@@ -113,7 +113,7 @@ describe Danger::GitHub do
 
       it "deletes existing issues danger doesnt need to say anything" do
         issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800", { :auto_pagination => true }).and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
 
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", "12").and_return({})
         @g.update_pull_request!(warnings: [], errors: [], messages: [])

--- a/spec/sources/github_spec.rb
+++ b/spec/sources/github_spec.rb
@@ -93,7 +93,7 @@ describe Danger::GitHub do
     describe "issue creation" do
       it "creates an issue if no danger comments exist" do
         issues = []
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800", { :auto_pagination => true }).and_return(issues)
 
         body = @g.generate_comment(warnings: ["hi"], errors: [], messages: [])
         expect(@g.client).to receive(:add_comment).with("artsy/eigen", "800", body).and_return({})
@@ -103,7 +103,7 @@ describe Danger::GitHub do
 
       it "updates the issue if no danger comments exist" do
         issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800", { :auto_pagination => true }).and_return(issues)
 
         body = @g.generate_comment(warnings: ["hi"], errors: [], messages: [])
         expect(@g.client).to receive(:update_comment).with("artsy/eigen", "12", body).and_return({})
@@ -113,7 +113,7 @@ describe Danger::GitHub do
 
       it "deletes existing issues danger doesnt need to say anything" do
         issues = [{ body: "generated_by_danger", id: "12" }]
-        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800").and_return(issues)
+        allow(@g.client).to receive(:issue_comments).with("artsy/eigen", "800", { :auto_pagination => true }).and_return(issues)
 
         expect(@g.client).to receive(:delete_comment).with("artsy/eigen", "12").and_return({})
         @g.update_pull_request!(warnings: [], errors: [], messages: [])


### PR DESCRIPTION
in #32 I wondered if there were x amounts of comments being downloaded, looks like 30 are downloaded. It's definitely possible that a PR can get that many comments, so I think it's worth letting danger deal with all of them.