### PR TITLE
Remove the specifity of claide as there's now cp 1.0

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_runtime_dependency 'claide', "~> 0.8"
+  spec.add_runtime_dependency 'claide'
   spec.add_runtime_dependency 'git', "~> 1.2.9"
   spec.add_runtime_dependency 'colored'
   spec.add_runtime_dependency 'nap'


### PR DESCRIPTION
Danger can't be used on a project with CLAide 1.0, as there are no breaking API changes it's fine to allow both. 